### PR TITLE
feat(eval): add scoring reliability evaluation set

### DIFF
--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -1,0 +1,87 @@
+# Scoring Reliability Evaluation Set
+
+## Purpose
+
+This evaluation set checks score reliability for the speaking scoring pipeline across IELTS Speaking Part 1, Part 2, and Part 3 responses at different target proficiency levels.
+
+## Methodology
+
+- We created 8 human-annotated transcript samples (`evaluation/samples/`) with expected scores for 5 dimensions:
+  - `fluency_score`
+  - `vocabulary_score`
+  - `grammar_score`
+  - `pronunciation_score`
+  - `overall_score`
+- Coverage includes lower, mid, and higher performance bands across all 3 speaking parts.
+- The runner executes each sample **N=3** times through the real async `score_speaking` pipeline.
+- For each dimension, we compute:
+  - mean
+  - standard deviation (run-to-run variability)
+  - delta from human expected (`mean - expected`)
+
+## How to Run
+
+From repository root:
+
+```bash
+python evaluation/run_eval.py
+```
+
+If `python` is not available in your shell, use:
+
+```bash
+python3 evaluation/run_eval.py
+```
+
+## Sample Set
+
+| ID | Part | Band | Transcript preview |
+|---|---|---|---|
+| S01 | part1 | band5 | "Uh, I think the internet is mostly good for people..." |
+| S02 | part1 | band6.5 | "I generally prefer working in the morning because..." |
+| S03 | part1 | band8 | "My hometown has changed dramatically over the past decade..." |
+| S04 | part2 | band5 | "Um, I read a book last month, but I forgot the name..." |
+| S05 | part2 | band6.5 | "I'd like to talk about a time when I helped my younger cousin..." |
+| S06 | part2 | band8+ | "One place that left a lasting impression on me was Kyoto..." |
+| S07 | part3 | band5.5 | "Well, I think online learning is easier for many people..." |
+| S08 | part3 | band7 | "In general, I believe governments should prioritize public transport..." |
+
+## Results
+
+Run executed on: `2026-04-01`
+
+- Output JSON: `evaluation/results/20260401_183747.json`
+- Runtime status: API unavailable for scoring due expired Gemini API key (`API_KEY_INVALID`)
+
+Actual runner summary output:
+
+```text
+ID  | band    | overall_expected | overall_mean | overall_stddev | overall_delta
+----+---------+------------------+--------------+----------------+--------------
+S01 | band5   | 5.00             | N/A          | N/A            | N/A
+S02 | band6.5 | 6.50             | N/A          | N/A            | N/A
+S03 | band8   | 8.00             | N/A          | N/A            | N/A
+S04 | band5   | 5.00             | N/A          | N/A            | N/A
+S05 | band6.5 | 6.50             | N/A          | N/A            | N/A
+S06 | band8+  | 8.00             | N/A          | N/A            | N/A
+S07 | band5.5 | 5.50             | N/A          | N/A            | N/A
+S08 | band7   | 7.00             | N/A          | N/A            | N/A
+```
+
+## Observations
+
+- All 24 scoring attempts (8 samples × 3 runs) failed with the same upstream error: `400 API key expired`.
+- Because there were no successful runs, reliability metrics (mean/stddev/delta) are currently unavailable (`N/A`) for every sample.
+- This run still validates runner behavior for failure handling:
+  - failed runs are captured without crashing,
+  - full error payloads are persisted in the result JSON,
+  - summary output remains structured and comparable across samples.
+- Once a valid API key is configured in `backend/.env`, rerunning the same command will produce real numeric reliability metrics.
+
+## Known Limitations
+
+- LLM non-determinism: repeated runs can differ even with identical input.
+- External API availability and credential validity can block evaluation runs.
+- No human inter-rater reliability baseline yet (single synthetic reference label per sample).
+- Pronunciation is inferred from transcript-only input in this evaluation; no real audio evidence is provided.
+- Small sample size (8 items) is useful for smoke-level reliability checks, not full psychometric validation.

--- a/evaluation/results/20260401_183602.json
+++ b/evaluation/results/20260401_183602.json
@@ -1,0 +1,971 @@
+{
+  "meta": {
+    "started_at": "2026-04-01T18:36:02",
+    "finished_at": "2026-04-01T18:36:11",
+    "runs_per_sample": 3,
+    "sample_count": 8,
+    "gemini_model": "gemini-3-flash-preview"
+  },
+  "samples": [
+    {
+      "sample_id": "S01",
+      "file": "S01_part1_band5.json",
+      "part": "part1",
+      "band_level": "band5",
+      "question": "Do you think the internet is good or bad?",
+      "notes": "Short answer, visible hesitation, simple vocabulary and structures",
+      "runs_total": 3,
+      "runs_success": 0,
+      "runs_failed": 3,
+      "dimensions": {
+        "fluency_score": {
+          "expected": 5.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "vocabulary_score": {
+          "expected": 5.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "grammar_score": {
+          "expected": 5.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "pronunciation_score": {
+          "expected": 5.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "overall_score": {
+          "expected": 5.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        }
+      },
+      "runs": [
+        {
+          "run": 1,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 2,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 3,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        }
+      ]
+    },
+    {
+      "sample_id": "S02",
+      "file": "S02_part1_band6_5.json",
+      "part": "part1",
+      "band_level": "band6.5",
+      "question": "Do you prefer to work in the morning or at night?",
+      "notes": "Mostly fluent with minor hesitation, adequate range, some complex clauses",
+      "runs_total": 3,
+      "runs_success": 0,
+      "runs_failed": 3,
+      "dimensions": {
+        "fluency_score": {
+          "expected": 6.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "vocabulary_score": {
+          "expected": 6.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "grammar_score": {
+          "expected": 6.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "pronunciation_score": {
+          "expected": 6.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "overall_score": {
+          "expected": 6.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        }
+      },
+      "runs": [
+        {
+          "run": 1,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 2,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 3,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        }
+      ]
+    },
+    {
+      "sample_id": "S03",
+      "file": "S03_part1_band8.json",
+      "part": "part1",
+      "band_level": "band8",
+      "question": "How has your hometown changed in recent years?",
+      "notes": "Fluent delivery, precise lexical choice, complex grammar, balanced viewpoint",
+      "runs_total": 3,
+      "runs_success": 0,
+      "runs_failed": 3,
+      "dimensions": {
+        "fluency_score": {
+          "expected": 8.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "vocabulary_score": {
+          "expected": 8.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "grammar_score": {
+          "expected": 8.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "pronunciation_score": {
+          "expected": 8.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "overall_score": {
+          "expected": 8.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        }
+      },
+      "runs": [
+        {
+          "run": 1,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 2,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 3,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        }
+      ]
+    },
+    {
+      "sample_id": "S04",
+      "file": "S04_part2_band5.json",
+      "part": "part2",
+      "band_level": "band5",
+      "question": "Describe a book you recently read. You should say what it was about, why you chose it, and whether you would recommend it.",
+      "notes": "Limited development, vague details, repetitive wording, mostly simple grammar",
+      "runs_total": 3,
+      "runs_success": 0,
+      "runs_failed": 3,
+      "dimensions": {
+        "fluency_score": {
+          "expected": 5.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "vocabulary_score": {
+          "expected": 5.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "grammar_score": {
+          "expected": 5.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "pronunciation_score": {
+          "expected": 5.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "overall_score": {
+          "expected": 5.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        }
+      },
+      "runs": [
+        {
+          "run": 1,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 2,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 3,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        }
+      ]
+    },
+    {
+      "sample_id": "S05",
+      "file": "S05_part2_band6_5.json",
+      "part": "part2",
+      "band_level": "band6.5",
+      "question": "Describe a time when you helped someone. You should say who the person was, what problem they had, what you did, and how you felt afterwards.",
+      "notes": "Coherent structure and clear sequence, adequate range, occasional formulaic phrasing",
+      "runs_total": 3,
+      "runs_success": 0,
+      "runs_failed": 3,
+      "dimensions": {
+        "fluency_score": {
+          "expected": 6.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "vocabulary_score": {
+          "expected": 6.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "grammar_score": {
+          "expected": 6.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "pronunciation_score": {
+          "expected": 6.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "overall_score": {
+          "expected": 6.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        }
+      },
+      "runs": [
+        {
+          "run": 1,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 2,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 3,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        }
+      ]
+    },
+    {
+      "sample_id": "S06",
+      "file": "S06_part2_band8_plus.json",
+      "part": "part2",
+      "band_level": "band8+",
+      "question": "Describe a place you visited that left a strong impression on you. You should say where it was, when you went there, what you did, and explain why it was memorable.",
+      "notes": "Extended and cohesive monologue with vivid detail, flexible vocabulary, complex control",
+      "runs_total": 3,
+      "runs_success": 0,
+      "runs_failed": 3,
+      "dimensions": {
+        "fluency_score": {
+          "expected": 8.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "vocabulary_score": {
+          "expected": 8.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "grammar_score": {
+          "expected": 8.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "pronunciation_score": {
+          "expected": 8.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "overall_score": {
+          "expected": 8.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        }
+      },
+      "runs": [
+        {
+          "run": 1,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 2,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 3,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        }
+      ]
+    },
+    {
+      "sample_id": "S07",
+      "file": "S07_part3_band5_5.json",
+      "part": "part3",
+      "band_level": "band5.5",
+      "question": "Why do some people prefer online learning while others prefer classroom learning?",
+      "notes": "Basic comparison with limited depth, repetitive lexical choices, simple linking",
+      "runs_total": 3,
+      "runs_success": 0,
+      "runs_failed": 3,
+      "dimensions": {
+        "fluency_score": {
+          "expected": 5.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "vocabulary_score": {
+          "expected": 5.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "grammar_score": {
+          "expected": 5.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "pronunciation_score": {
+          "expected": 5.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "overall_score": {
+          "expected": 5.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        }
+      },
+      "runs": [
+        {
+          "run": 1,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 2,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 3,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        }
+      ]
+    },
+    {
+      "sample_id": "S08",
+      "file": "S08_part3_band7.json",
+      "part": "part3",
+      "band_level": "band7",
+      "question": "Do you think governments should invest more in public transport than in roads for private cars? Why?",
+      "notes": "Clear position with balanced reasoning and examples; minor slips but generally strong control",
+      "runs_total": 3,
+      "runs_success": 0,
+      "runs_failed": 3,
+      "dimensions": {
+        "fluency_score": {
+          "expected": 7.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "vocabulary_score": {
+          "expected": 7.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "grammar_score": {
+          "expected": 7.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "pronunciation_score": {
+          "expected": 7.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "overall_score": {
+          "expected": 7.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        }
+      },
+      "runs": [
+        {
+          "run": 1,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 2,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 3,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        }
+      ]
+    }
+  ]
+}

--- a/evaluation/results/20260401_183747.json
+++ b/evaluation/results/20260401_183747.json
@@ -1,0 +1,971 @@
+{
+  "meta": {
+    "started_at": "2026-04-01T18:37:47",
+    "finished_at": "2026-04-01T18:37:53",
+    "runs_per_sample": 3,
+    "sample_count": 8,
+    "gemini_model": "gemini-3-flash-preview"
+  },
+  "samples": [
+    {
+      "sample_id": "S01",
+      "file": "S01_part1_band5.json",
+      "part": "part1",
+      "band_level": "band5",
+      "question": "Do you think the internet is good or bad?",
+      "notes": "Short answer, visible hesitation, simple vocabulary and structures",
+      "runs_total": 3,
+      "runs_success": 0,
+      "runs_failed": 3,
+      "dimensions": {
+        "fluency_score": {
+          "expected": 5.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "vocabulary_score": {
+          "expected": 5.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "grammar_score": {
+          "expected": 5.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "pronunciation_score": {
+          "expected": 5.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "overall_score": {
+          "expected": 5.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        }
+      },
+      "runs": [
+        {
+          "run": 1,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 2,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 3,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        }
+      ]
+    },
+    {
+      "sample_id": "S02",
+      "file": "S02_part1_band6_5.json",
+      "part": "part1",
+      "band_level": "band6.5",
+      "question": "Do you prefer to work in the morning or at night?",
+      "notes": "Mostly fluent with minor hesitation, adequate range, some complex clauses",
+      "runs_total": 3,
+      "runs_success": 0,
+      "runs_failed": 3,
+      "dimensions": {
+        "fluency_score": {
+          "expected": 6.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "vocabulary_score": {
+          "expected": 6.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "grammar_score": {
+          "expected": 6.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "pronunciation_score": {
+          "expected": 6.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "overall_score": {
+          "expected": 6.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        }
+      },
+      "runs": [
+        {
+          "run": 1,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 2,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 3,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        }
+      ]
+    },
+    {
+      "sample_id": "S03",
+      "file": "S03_part1_band8.json",
+      "part": "part1",
+      "band_level": "band8",
+      "question": "How has your hometown changed in recent years?",
+      "notes": "Fluent delivery, precise lexical choice, complex grammar, balanced viewpoint",
+      "runs_total": 3,
+      "runs_success": 0,
+      "runs_failed": 3,
+      "dimensions": {
+        "fluency_score": {
+          "expected": 8.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "vocabulary_score": {
+          "expected": 8.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "grammar_score": {
+          "expected": 8.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "pronunciation_score": {
+          "expected": 8.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "overall_score": {
+          "expected": 8.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        }
+      },
+      "runs": [
+        {
+          "run": 1,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 2,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 3,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        }
+      ]
+    },
+    {
+      "sample_id": "S04",
+      "file": "S04_part2_band5.json",
+      "part": "part2",
+      "band_level": "band5",
+      "question": "Describe a book you recently read. You should say what it was about, why you chose it, and whether you would recommend it.",
+      "notes": "Limited development, vague details, repetitive wording, mostly simple grammar",
+      "runs_total": 3,
+      "runs_success": 0,
+      "runs_failed": 3,
+      "dimensions": {
+        "fluency_score": {
+          "expected": 5.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "vocabulary_score": {
+          "expected": 5.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "grammar_score": {
+          "expected": 5.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "pronunciation_score": {
+          "expected": 5.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "overall_score": {
+          "expected": 5.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        }
+      },
+      "runs": [
+        {
+          "run": 1,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 2,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 3,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        }
+      ]
+    },
+    {
+      "sample_id": "S05",
+      "file": "S05_part2_band6_5.json",
+      "part": "part2",
+      "band_level": "band6.5",
+      "question": "Describe a time when you helped someone. You should say who the person was, what problem they had, what you did, and how you felt afterwards.",
+      "notes": "Coherent structure and clear sequence, adequate range, occasional formulaic phrasing",
+      "runs_total": 3,
+      "runs_success": 0,
+      "runs_failed": 3,
+      "dimensions": {
+        "fluency_score": {
+          "expected": 6.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "vocabulary_score": {
+          "expected": 6.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "grammar_score": {
+          "expected": 6.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "pronunciation_score": {
+          "expected": 6.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "overall_score": {
+          "expected": 6.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        }
+      },
+      "runs": [
+        {
+          "run": 1,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 2,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 3,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        }
+      ]
+    },
+    {
+      "sample_id": "S06",
+      "file": "S06_part2_band8_plus.json",
+      "part": "part2",
+      "band_level": "band8+",
+      "question": "Describe a place you visited that left a strong impression on you. You should say where it was, when you went there, what you did, and explain why it was memorable.",
+      "notes": "Extended and cohesive monologue with vivid detail, flexible vocabulary, complex control",
+      "runs_total": 3,
+      "runs_success": 0,
+      "runs_failed": 3,
+      "dimensions": {
+        "fluency_score": {
+          "expected": 8.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "vocabulary_score": {
+          "expected": 8.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "grammar_score": {
+          "expected": 8.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "pronunciation_score": {
+          "expected": 8.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "overall_score": {
+          "expected": 8.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        }
+      },
+      "runs": [
+        {
+          "run": 1,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 2,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 3,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        }
+      ]
+    },
+    {
+      "sample_id": "S07",
+      "file": "S07_part3_band5_5.json",
+      "part": "part3",
+      "band_level": "band5.5",
+      "question": "Why do some people prefer online learning while others prefer classroom learning?",
+      "notes": "Basic comparison with limited depth, repetitive lexical choices, simple linking",
+      "runs_total": 3,
+      "runs_success": 0,
+      "runs_failed": 3,
+      "dimensions": {
+        "fluency_score": {
+          "expected": 5.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "vocabulary_score": {
+          "expected": 5.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "grammar_score": {
+          "expected": 5.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "pronunciation_score": {
+          "expected": 5.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "overall_score": {
+          "expected": 5.5,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        }
+      },
+      "runs": [
+        {
+          "run": 1,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 2,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 3,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        }
+      ]
+    },
+    {
+      "sample_id": "S08",
+      "file": "S08_part3_band7.json",
+      "part": "part3",
+      "band_level": "band7",
+      "question": "Do you think governments should invest more in public transport than in roads for private cars? Why?",
+      "notes": "Clear position with balanced reasoning and examples; minor slips but generally strong control",
+      "runs_total": 3,
+      "runs_success": 0,
+      "runs_failed": 3,
+      "dimensions": {
+        "fluency_score": {
+          "expected": 7.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "vocabulary_score": {
+          "expected": 7.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "grammar_score": {
+          "expected": 7.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "pronunciation_score": {
+          "expected": 7.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        },
+        "overall_score": {
+          "expected": 7.0,
+          "mean": null,
+          "stddev": null,
+          "delta": null
+        }
+      },
+      "runs": [
+        {
+          "run": 1,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 2,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        },
+        {
+          "run": 3,
+          "status": "failed",
+          "error": "llm_generation_failed",
+          "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+          "raw": {
+            "error": "llm_generation_failed",
+            "detail": "400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]",
+            "fluency_score": 0.0,
+            "vocabulary_score": 0.0,
+            "grammar_score": 0.0,
+            "pronunciation_score": 0.0,
+            "overall_score": 0.0,
+            "overall_feedback": "❌ Scoring Failed: The AI model refused to score this transcript or encountered an error. Detail: 400 API key expired. Please renew the API key. [reason: \"API_KEY_INVALID\"\ndomain: \"googleapis.com\"\nmetadata {\n  key: \"service\"\n  value: \"generativelanguage.googleapis.com\"\n}\n, locale: \"en-US\"\nmessage: \"API key expired. Please renew the API key.\"\n]\n\n(This sometimes happens if safety filters incorrectly flag the speech.)",
+            "fluency_feedback": "-",
+            "vocabulary_feedback": "-",
+            "grammar_feedback": "-",
+            "pronunciation_feedback": "-",
+            "key_improvements": [
+              "Could not parse assessment."
+            ],
+            "sample_answer": ""
+          },
+          "scores": null
+        }
+      ]
+    }
+  ]
+}

--- a/evaluation/run_eval.py
+++ b/evaluation/run_eval.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import os
+import statistics
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+BACKEND_DIR = PROJECT_ROOT / "backend"
+SAMPLES_DIR = PROJECT_ROOT / "evaluation" / "samples"
+RESULTS_DIR = PROJECT_ROOT / "evaluation" / "results"
+RUNS_PER_SAMPLE = 3
+
+SCORE_KEYS = [
+    "fluency_score",
+    "vocabulary_score",
+    "grammar_score",
+    "pronunciation_score",
+    "overall_score",
+]
+
+
+sys.path.insert(0, str(BACKEND_DIR))
+load_dotenv(BACKEND_DIR / ".env")
+
+score_speaking = importlib.import_module("app.services.scoring_service").score_speaking
+
+
+def load_samples() -> list[dict[str, Any]]:
+    sample_paths = sorted(SAMPLES_DIR.glob("*.json"))
+    if not sample_paths:
+        raise FileNotFoundError(f"No sample files found in {SAMPLES_DIR}")
+
+    samples: list[dict[str, Any]] = []
+    for path in sample_paths:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["_file"] = path.name
+        samples.append(payload)
+    return samples
+
+
+def _safe_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _fmt(value: float | None, digits: int = 2, signed: bool = False) -> str:
+    if value is None:
+        return "N/A"
+    if signed:
+        return f"{value:+.{digits}f}"
+    return f"{value:.{digits}f}"
+
+
+def _print_table(headers: list[str], rows: list[list[str]]) -> None:
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+
+    header_line = " | ".join(f"{h:<{widths[i]}}" for i, h in enumerate(headers))
+    sep_line = "-+-".join("-" * w for w in widths)
+    print(header_line)
+    print(sep_line)
+    for row in rows:
+        print(" | ".join(f"{cell:<{widths[i]}}" for i, cell in enumerate(row)))
+
+
+async def run_one(sample: dict[str, Any], run_index: int) -> dict[str, Any]:
+    try:
+        result = await score_speaking(
+            sample["transcript"],
+            sample["question"],
+            sample["part"],
+        )
+    except Exception as exc:
+        return {
+            "run": run_index,
+            "status": "failed",
+            "error": "exception",
+            "detail": str(exc),
+            "raw": None,
+            "scores": None,
+        }
+
+    if not isinstance(result, dict):
+        return {
+            "run": run_index,
+            "status": "failed",
+            "error": "invalid_response",
+            "detail": f"Unexpected response type: {type(result).__name__}",
+            "raw": result,
+            "scores": None,
+        }
+
+    if "error" in result:
+        return {
+            "run": run_index,
+            "status": "failed",
+            "error": result.get("error"),
+            "detail": result.get("detail"),
+            "raw": result,
+            "scores": None,
+        }
+
+    extracted = {k: _safe_float(result.get(k)) for k in SCORE_KEYS}
+    if any(v is None for v in extracted.values()):
+        return {
+            "run": run_index,
+            "status": "failed",
+            "error": "missing_scores",
+            "detail": "One or more score keys missing or non-numeric",
+            "raw": result,
+            "scores": extracted,
+        }
+
+    return {
+        "run": run_index,
+        "status": "ok",
+        "error": None,
+        "detail": None,
+        "raw": result,
+        "scores": extracted,
+    }
+
+
+def aggregate(sample: dict[str, Any], runs: list[dict[str, Any]]) -> dict[str, Any]:
+    expected = sample["human_expected"]
+    ok_runs = [r for r in runs if r["status"] == "ok"]
+
+    dimensions: dict[str, dict[str, float | None]] = {}
+    for key in SCORE_KEYS:
+        vals = [
+            r["scores"][key]
+            for r in ok_runs
+            if r["scores"] and r["scores"][key] is not None
+        ]
+        expected_value = _safe_float(expected.get(key))
+        mean_val = statistics.mean(vals) if vals else None
+        std_val = (
+            statistics.stdev(vals)
+            if len(vals) >= 2
+            else (0.0 if len(vals) == 1 else None)
+        )
+        delta = (
+            (mean_val - expected_value)
+            if (mean_val is not None and expected_value is not None)
+            else None
+        )
+
+        dimensions[key] = {
+            "expected": expected_value,
+            "mean": mean_val,
+            "stddev": std_val,
+            "delta": delta,
+        }
+
+    return {
+        "sample_id": sample["id"],
+        "file": sample["_file"],
+        "part": sample["part"],
+        "band_level": sample["band_level"],
+        "question": sample["question"],
+        "notes": sample.get("notes", ""),
+        "runs_total": len(runs),
+        "runs_success": len(ok_runs),
+        "runs_failed": len(runs) - len(ok_runs),
+        "dimensions": dimensions,
+        "runs": runs,
+    }
+
+
+async def main() -> None:
+    samples = load_samples()
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    started_at = datetime.now().isoformat(timespec="seconds")
+
+    all_results: list[dict[str, Any]] = []
+    for sample in samples:
+        runs: list[dict[str, Any]] = []
+        for run_idx in range(1, RUNS_PER_SAMPLE + 1):
+            runs.append(await run_one(sample, run_idx))
+        all_results.append(aggregate(sample, runs))
+
+    payload = {
+        "meta": {
+            "started_at": started_at,
+            "finished_at": datetime.now().isoformat(timespec="seconds"),
+            "runs_per_sample": RUNS_PER_SAMPLE,
+            "sample_count": len(samples),
+            "gemini_model": os.getenv("GEMINI_MODEL", ""),
+        },
+        "samples": all_results,
+    }
+
+    out_path = RESULTS_DIR / f"{stamp}.json"
+    out_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    headers = [
+        "ID",
+        "band",
+        "overall_expected",
+        "overall_mean",
+        "overall_stddev",
+        "overall_delta",
+    ]
+    rows: list[list[str]] = []
+    for item in all_results:
+        overall = item["dimensions"]["overall_score"]
+        rows.append(
+            [
+                item["sample_id"],
+                item["band_level"],
+                _fmt(overall["expected"]),
+                _fmt(overall["mean"]),
+                _fmt(overall["stddev"]),
+                _fmt(overall["delta"], signed=True),
+            ]
+        )
+
+    print(f"Saved full results to: {out_path}")
+    print()
+    _print_table(headers, rows)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/evaluation/samples/S01_part1_band5.json
+++ b/evaluation/samples/S01_part1_band5.json
@@ -1,0 +1,15 @@
+{
+  "id": "S01",
+  "part": "part1",
+  "band_level": "band5",
+  "question": "Do you think the internet is good or bad?",
+  "transcript": "Uh, I think the internet is mostly good for people. I use it every day to check messages and study English, so it helps me a lot. But, um, sometimes it is bad because people spend too much time scrolling and they forget real life. Also there is fake news, so we need to be careful.",
+  "human_expected": {
+    "fluency_score": 5.0,
+    "vocabulary_score": 5.0,
+    "grammar_score": 5.0,
+    "pronunciation_score": 5.0,
+    "overall_score": 5.0
+  },
+  "notes": "Short answer, visible hesitation, simple vocabulary and structures"
+}

--- a/evaluation/samples/S02_part1_band6_5.json
+++ b/evaluation/samples/S02_part1_band6_5.json
@@ -1,0 +1,15 @@
+{
+  "id": "S02",
+  "part": "part1",
+  "band_level": "band6.5",
+  "question": "Do you prefer to work in the morning or at night?",
+  "transcript": "I generally prefer working in the morning because my mind feels clearer at that time. I can plan my tasks better and finish difficult work before noon. That said, I sometimes study at night when deadlines are close, although I get tired more easily. So, overall, morning is better for productivity, but night can be useful for quiet focus.",
+  "human_expected": {
+    "fluency_score": 6.5,
+    "vocabulary_score": 6.5,
+    "grammar_score": 6.5,
+    "pronunciation_score": 6.5,
+    "overall_score": 6.5
+  },
+  "notes": "Mostly fluent with minor hesitation, adequate range, some complex clauses"
+}

--- a/evaluation/samples/S03_part1_band8.json
+++ b/evaluation/samples/S03_part1_band8.json
@@ -1,0 +1,15 @@
+{
+  "id": "S03",
+  "part": "part1",
+  "band_level": "band8",
+  "question": "How has your hometown changed in recent years?",
+  "transcript": "My hometown has changed dramatically over the past decade. What used to be a quiet industrial town has gradually transformed into a tech-oriented city with co-working spaces, start-up hubs, and much better public transport. On the upside, people now have broader career options and a more cosmopolitan lifestyle. On the downside, housing costs have skyrocketed, which has pushed some long-term residents to the outskirts. Overall, though, I'd say the city has become more dynamic and forward-looking.",
+  "human_expected": {
+    "fluency_score": 8.0,
+    "vocabulary_score": 8.0,
+    "grammar_score": 8.0,
+    "pronunciation_score": 8.0,
+    "overall_score": 8.0
+  },
+  "notes": "Fluent delivery, precise lexical choice, complex grammar, balanced viewpoint"
+}

--- a/evaluation/samples/S04_part2_band5.json
+++ b/evaluation/samples/S04_part2_band5.json
@@ -1,0 +1,15 @@
+{
+  "id": "S04",
+  "part": "part2",
+  "band_level": "band5",
+  "question": "Describe a book you recently read. You should say what it was about, why you chose it, and whether you would recommend it.",
+  "transcript": "Um, I read a book last month, but I forgot the name. It is about a man who wants to be successful in business. I chose it because my friend said it is useful. The story is okay, not very interesting for me. Uh, I think the language is easy, so I can understand most parts. There are some good ideas about hard work. But some chapters are long and a little boring. I finished it quickly because I wanted to practice reading. I maybe recommend it for beginners, but not for people who like deep stories.",
+  "human_expected": {
+    "fluency_score": 5.0,
+    "vocabulary_score": 5.0,
+    "grammar_score": 5.0,
+    "pronunciation_score": 5.0,
+    "overall_score": 5.0
+  },
+  "notes": "Limited development, vague details, repetitive wording, mostly simple grammar"
+}

--- a/evaluation/samples/S05_part2_band6_5.json
+++ b/evaluation/samples/S05_part2_band6_5.json
@@ -1,0 +1,15 @@
+{
+  "id": "S05",
+  "part": "part2",
+  "band_level": "band6.5",
+  "question": "Describe a time when you helped someone. You should say who the person was, what problem they had, what you did, and how you felt afterwards.",
+  "transcript": "I'd like to talk about a time when I helped my younger cousin prepare for a school interview. She was quite nervous because it was her first formal interview and she didn't know how to answer open questions. First, I asked her to write down common topics, such as hobbies, study habits, and future goals. Then we practiced together every evening for about a week. I gave her feedback on eye contact and encouraged her to speak in complete sentences instead of one-word answers. On the interview day, she still felt anxious, but she managed to stay calm. Later she told me the questions were very similar to the ones we had practiced. She eventually got accepted by the school. I felt really satisfied because my support made a practical difference.",
+  "human_expected": {
+    "fluency_score": 6.5,
+    "vocabulary_score": 6.5,
+    "grammar_score": 6.5,
+    "pronunciation_score": 6.5,
+    "overall_score": 6.5
+  },
+  "notes": "Coherent structure and clear sequence, adequate range, occasional formulaic phrasing"
+}

--- a/evaluation/samples/S06_part2_band8_plus.json
+++ b/evaluation/samples/S06_part2_band8_plus.json
@@ -1,0 +1,15 @@
+{
+  "id": "S06",
+  "part": "part2",
+  "band_level": "band8+",
+  "question": "Describe a place you visited that left a strong impression on you. You should say where it was, when you went there, what you did, and explain why it was memorable.",
+  "transcript": "One place that left a lasting impression on me was Kyoto, which I visited during the spring two years ago. I had seen photos of the city before, but the atmosphere in person was far more captivating than I expected. Early in the morning, I walked through narrow streets lined with wooden houses, and the whole area felt calm and almost cinematic. Later, I visited several temples, where I spent time observing small architectural details rather than rushing from one site to another. In the afternoon, I joined a short tea ceremony workshop, and that experience helped me understand how deeply ritual is connected to daily life there. What struck me most was the contrast between tradition and modern convenience, because you could step out of a quiet shrine and immediately find efficient transport and lively cafés. I also remember having long conversations with local shop owners, who were patient and surprisingly open to sharing stories about seasonal customs. By the end of the trip, I felt mentally refreshed and more attentive to slower, more deliberate ways of living. That's why the visit remains memorable: it wasn't just visually beautiful, it genuinely changed how I think about time, routine, and priorities.",
+  "human_expected": {
+    "fluency_score": 8.5,
+    "vocabulary_score": 8.5,
+    "grammar_score": 8.0,
+    "pronunciation_score": 8.0,
+    "overall_score": 8.0
+  },
+  "notes": "Extended and cohesive monologue with vivid detail, flexible vocabulary, complex control"
+}

--- a/evaluation/samples/S07_part3_band5_5.json
+++ b/evaluation/samples/S07_part3_band5_5.json
@@ -1,0 +1,15 @@
+{
+  "id": "S07",
+  "part": "part3",
+  "band_level": "band5.5",
+  "question": "Why do some people prefer online learning while others prefer classroom learning?",
+  "transcript": "Well, I think online learning is easier for many people because they can study at home and save time. In classroom learning, students can ask teachers directly, so this part is better. But online classes are sometimes boring and students lose focus quickly. Also, in my opinion, classroom learning gives more pressure, and pressure can help some students study harder. So both ways are okay, but it depends on the person.",
+  "human_expected": {
+    "fluency_score": 5.5,
+    "vocabulary_score": 5.5,
+    "grammar_score": 5.5,
+    "pronunciation_score": 5.5,
+    "overall_score": 5.5
+  },
+  "notes": "Basic comparison with limited depth, repetitive lexical choices, simple linking"
+}

--- a/evaluation/samples/S08_part3_band7.json
+++ b/evaluation/samples/S08_part3_band7.json
@@ -1,0 +1,15 @@
+{
+  "id": "S08",
+  "part": "part3",
+  "band_level": "band7",
+  "question": "Do you think governments should invest more in public transport than in roads for private cars? Why?",
+  "transcript": "In general, I believe governments should prioritize public transport, especially in large cities where congestion is already severe. A reliable metro or bus network can move far more people with lower environmental impact than private cars. That said, road investment is still necessary in suburban or rural areas, where residents may not have realistic alternatives. I think the key is not choosing one option blindly, but allocating budgets according to local travel patterns. If authorities only expand roads, traffic often returns to the same level within a few years because demand increases. By contrast, better public transport can reduce both commute time and inequality, since lower-income groups benefit the most.",
+  "human_expected": {
+    "fluency_score": 7.0,
+    "vocabulary_score": 7.0,
+    "grammar_score": 7.0,
+    "pronunciation_score": 7.0,
+    "overall_score": 7.0
+  },
+  "notes": "Clear position with balanced reasoning and examples; minor slips but generally strong control"
+}


### PR DESCRIPTION
## Summary

Closes #19.

Adds a reproducible speaking scoring evaluation set under `evaluation/` so scoring behavior can be checked against a small curated sample pack.

## Changes

- add `evaluation/run_eval.py` to run the evaluation set and write result snapshots
- add `evaluation/samples/` JSON fixtures covering Part 1, Part 2, and Part 3 answers across multiple target band levels
- add `evaluation/README.md` documenting usage and output layout
- add two generated result snapshots under `evaluation/results/`

## Validation

- `python3 -m py_compile evaluation/run_eval.py`
